### PR TITLE
updated multiplicity of vcf to (un)aligned reads nodes

### DIFF
--- a/gdcdictionary/schemas/variant_call_file.yaml
+++ b/gdcdictionary/schemas/variant_call_file.yaml
@@ -37,13 +37,13 @@ links:
         backref: variant_call_files
         label: data_from
         target_type: aligned_reads_file
-        multiplicity: one_to_many
+        multiplicity: many_to_many
         required: false
       - name: unaligned_reads_files
         backref: variant_call_files
         label: data_from
         target_type: unaligned_reads_file
-        multiplicity: one_to_many
+        multiplicity: many_to_many
         required: false
 
 required:


### PR DESCRIPTION
Changed VCF to (un)aligned reads nodes multiplicity to "many_to_many" so a single VCF can link to both unaligned reads files.